### PR TITLE
Add placeholders for websiteName and websitePushId

### DIFF
--- a/data/safariPushPackage.base/website.json
+++ b/data/safariPushPackage.base/website.json
@@ -1,6 +1,6 @@
 {
-    "websiteName": "WebsiteName",
-    "websitePushID": "web.com.domain",
+    "websiteName": "{{ websiteName }}",
+    "websitePushID": "{{ websitePushId }}",
     "allowedDomains": ["http://{{ host }}", "https://{{ host }}"],
     "urlFormatString": "http://{{ host }}/%@",
     "authenticationToken": "{{ userId }}",

--- a/src/JWage/APNS/Safari/PackageGenerator.php
+++ b/src/JWage/APNS/Safari/PackageGenerator.php
@@ -24,17 +24,36 @@ class PackageGenerator
     protected $host;
 
     /**
+     * @var string
+     */
+    protected $websiteName;
+
+    /**
+     * @var string
+     */
+    protected $websitePushId;
+
+    /**
      * Construct.
      *
      * @param \JWage\APNS\Certificate $certificate
      * @param string $basePushPackagePath
      * @param string $host
+     * @param string $websiteName
+     * @param string $websitePushId
      */
-    public function __construct(Certificate $certificate, $basePushPackagePath, $host)
-    {
+    public function __construct(
+        Certificate $certificate,
+        $basePushPackagePath,
+        $host,
+        $websiteName = '',
+        $websitePushId = ''
+    ) {
         $this->certificate = $certificate;
         $this->basePushPackagePath = $basePushPackagePath;
         $this->host = $host;
+        $this->websiteName = $websiteName;
+        $this->websitePushId = $websitePushId;
     }
 
     /**
@@ -106,6 +125,8 @@ class PackageGenerator
                 $websiteJson = file_get_contents($filePath);
                 $websiteJson = str_replace('{{ userId }}', $package->getUserId(), $websiteJson);
                 $websiteJson = str_replace('{{ host }}', $this->host, $websiteJson);
+                $websiteJson = str_replace('{{ websiteName }}', $this->websiteName, $websiteJson);
+                $websiteJson = str_replace('{{ websitePushId }}', $this->websitePushId, $websiteJson);
                 file_put_contents($filePath, $websiteJson);
             }
         }

--- a/tests/JWage/APNS/Tests/Safari/PackageGeneratorTest.php
+++ b/tests/JWage/APNS/Tests/Safari/PackageGeneratorTest.php
@@ -21,7 +21,7 @@ class PackageGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->certificate = new Certificate('', 'password');
         $this->packageGenerator = new PackageGeneratorStub(
-            $this->certificate, $this->basePushPackagePath, 'host.com'
+            $this->certificate, $this->basePushPackagePath, 'host.com', 'WebsiteName', 'web.com.domain'
         );
     }
 


### PR DESCRIPTION
websiteName and websitePushId can be stored in db for ex. so it's uncomfortably to have them hardcoded in file
